### PR TITLE
Fix leaked global variable 'it'

### DIFF
--- a/cartesian.js
+++ b/cartesian.js
@@ -56,7 +56,7 @@ function expand(expr) {
     res = [{}]
     for(var name in expr) {
         // find the property descriptor, even if it is in a base class
-        for(it = expr; it != null; it = it.__proto__) {
+        for(var it = expr; it != null; it = it.__proto__) {
             var desc = Object.getOwnPropertyDescriptor(it, name)
             if(desc != undefined) break
         }


### PR DESCRIPTION
Found when using this with a test runner. Suddenly my suite was getting `it is not a function` and was not only very confused by the wording of the error, but I was also very confused when I dug into what was happening.